### PR TITLE
feat: configure ClearML to use clearml.yaml for authentication

### DIFF
--- a/config/clearml.yaml
+++ b/config/clearml.yaml
@@ -5,6 +5,7 @@ clearml:
     files_server: https://files.clear.ml
     credentials:
       # Replace with your actual ClearML credentials
+      # These credentials will be used for authentication instead of environment variables or ~/clearml.conf
       access_key: YOUR_ACCESS_KEY_HERE
       secret_key: YOUR_SECRET_KEY_HERE
   

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -83,6 +83,22 @@ class FacialKeypointsTrainer:
     def _init_clearml(self, config: Dict[str, Any]):
         """Initialize ClearML task and logger."""
         try:
+            # Configure ClearML authentication from YAML if credentials are provided
+            api_config = config.get('api', {})
+            credentials = api_config.get('credentials', {})
+            
+            if credentials.get('access_key') and credentials.get('secret_key'):
+                # Set up authentication using credentials from YAML
+                from clearml import Task
+                Task.set_credentials(
+                    api_host=api_config.get('api_server', 'https://api.clear.ml'),
+                    web_host=api_config.get('web_server', 'https://app.clear.ml'),
+                    files_host=api_config.get('files_server', 'https://files.clear.ml'),
+                    key=credentials['access_key'],
+                    secret=credentials['secret_key']
+                )
+                print("ClearML authentication configured from YAML file")
+            
             # Extract experiment configuration
             experiment_config = config.get('experiment', {})
             


### PR DESCRIPTION
This PR updates ClearML authentication to use the clearml.yaml configuration file instead of relying on environment variables or default settings.

## Changes
- Modified `src/training/trainer.py` to use `Task.set_credentials()` with YAML config
- Added authentication setup before `Task.init()`
- Use API server URLs and credentials from clearml.yaml
- Added fallback to default ClearML behavior if no credentials in YAML
- Updated clearml.yaml comments to clarify authentication usage

Fixes #16

Generated with [Claude Code](https://claude.ai/code)