### PR TITLE
fix: resolve app.py import errors

### DIFF
--- a/src/utils/inference.py
+++ b/src/utils/inference.py
@@ -10,7 +10,7 @@ import pandas as pd
 from typing import Tuple, Union, Optional, List, Dict
 from PIL import Image
 import albumentations as A
-from ..data.preprocessing import DataPreprocessor
+from data.preprocessing import DataPreprocessor
 
 
 class KeypointsPredictor:


### PR DESCRIPTION
Fixed ImportError in src/utils/inference.py that was preventing webapp/app.py from running.

Converted relative import to absolute import to fix the issue when importing from webapp/app.py that adds src to sys.path.

Fixes ##20

Generated with [Claude Code](https://claude.ai/code)