### PR TITLE
fix: resolve numpy/tensor conversion error in submission generation

### DIFF
--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -56,6 +56,7 @@ class DataPreprocessor:
                 A.GaussianBlur(blur_limit=3, p=0.3),
             ], p=0.5),
             A.Normalize(mean=[0.485], std=[0.229]),  # ImageNet stats for grayscale
+            ToTensorV2(),
         ], keypoint_params=A.KeypointParams(
             format='xy',
             remove_invisible=False,
@@ -72,6 +73,7 @@ class DataPreprocessor:
         return A.Compose([
             A.Resize(height=self.image_size[0], width=self.image_size[1]),
             A.Normalize(mean=[0.485], std=[0.229]),
+            ToTensorV2(),
         ], keypoint_params=A.KeypointParams(
             format='xy',
             remove_invisible=False
@@ -87,6 +89,7 @@ class DataPreprocessor:
         return A.Compose([
             A.Resize(height=self.image_size[0], width=self.image_size[1]),
             A.Normalize(mean=[0.485], std=[0.229]),
+            ToTensorV2(),
         ])
     
     @staticmethod


### PR DESCRIPTION
## Summary

- Fix numpy/tensor conversion error in submission file generation
- Add ToTensorV2 to all albumentations transform pipelines
- Ensure consistent tensor handling throughout the inference pipeline

## Changes

### src/data/preprocessing.py
- Added ToTensorV2() to train, validation, and inference transforms
- Ensures proper numpy array to PyTorch tensor conversion

### src/utils/inference.py
- Removed manual tensor conversion since ToTensorV2 handles it
- Cleaned up preprocessing pipeline

## Issue Fixed

This resolves the error: `'numpy.ndarray' object has no attribute 'unsqueeze'`

Closes #26

Generated with [Claude Code](https://claude.ai/code)