### PR TITLE
fix: resolve PyTorch tensor copying warnings during training

### DIFF
--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -180,9 +180,17 @@ class FacialKeypointsDataset(Dataset):
         if self.transform:
             image = self.transform(image)
         else:
-            image = torch.tensor(image, dtype=torch.float32)
+            # Convert numpy array to tensor
+            if isinstance(image, torch.Tensor):
+                image = image.clone().detach().to(torch.float32)
+            else:
+                image = torch.tensor(image, dtype=torch.float32)
         
-        keypoints = torch.tensor(keypoints, dtype=torch.float32)
+        # Convert keypoints to tensor
+        if isinstance(keypoints, torch.Tensor):
+            keypoints = keypoints.clone().detach().to(torch.float32)
+        else:
+            keypoints = torch.tensor(keypoints, dtype=torch.float32)
         
         return {
             'image': image,


### PR DESCRIPTION
Fixes #34

Resolves PyTorch warning about tensor copying in dataset.py by using the recommended `clone().detach()` method instead of `torch.tensor()` when copying existing tensors.

## Changes
- Added proper isinstance checks for both image and keypoints tensors
- Use `clone().detach().to(dtype)` for existing tensors
- Maintains backward compatibility for numpy array inputs

Generated with [Claude Code](https://claude.ai/code)