### PR TITLE
fix: correct model coordinate clamping from [0,96] to [0,1] range

### DIFF
--- a/src/models/cnn_model.py
+++ b/src/models/cnn_model.py
@@ -62,7 +62,7 @@ class BasicCNN(nn.Module):
             x: Input tensor of shape (batch_size, 1, 96, 96)
             
         Returns:
-            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 96]
+            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 1]
         """
         # Convolutional layers with activation and pooling
         x = self.pool(F.relu(self.bn1(self.conv1(x))))
@@ -80,8 +80,8 @@ class BasicCNN(nn.Module):
         x = self.dropout(x)
         x = self.fc3(x)
         
-        # Clamp coordinates to [0, 96] range for 96x96 images
-        x = torch.clamp(x, min=0.0, max=96.0)
+        # Clamp coordinates to [0, 1] range (normalized coordinates)
+        x = torch.clamp(x, min=0.0, max=1.0)
         
         return x
 
@@ -158,12 +158,12 @@ class ResNetKeypointDetector(nn.Module):
             x: Input tensor of shape (batch_size, 1, 96, 96)
             
         Returns:
-            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 96]
+            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 1]
         """
         x = self.backbone(x)
         
-        # Clamp coordinates to [0, 96] range for 96x96 images
-        x = torch.clamp(x, min=0.0, max=96.0)
+        # Clamp coordinates to [0, 1] range (normalized coordinates)
+        x = torch.clamp(x, min=0.0, max=1.0)
         
         return x
 
@@ -235,12 +235,12 @@ class EfficientNetKeypointDetector(nn.Module):
             x: Input tensor of shape (batch_size, 1, 96, 96)
             
         Returns:
-            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 96]
+            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 1]
         """
         x = self.backbone(x)
         
-        # Clamp coordinates to [0, 96] range for 96x96 images
-        x = torch.clamp(x, min=0.0, max=96.0)
+        # Clamp coordinates to [0, 1] range (normalized coordinates)
+        x = torch.clamp(x, min=0.0, max=1.0)
         
         return x
 
@@ -308,7 +308,7 @@ class DeepCNN(nn.Module):
             x: Input tensor of shape (batch_size, 1, 96, 96)
             
         Returns:
-            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 96]
+            Output tensor of shape (batch_size, num_keypoints) with coordinates clamped to [0, 1]
         """
         # First block
         x = F.relu(self.conv1(x))
@@ -346,8 +346,8 @@ class DeepCNN(nn.Module):
         x = self.dropout(x)
         x = self.fc6(x)
         
-        # Clamp coordinates to [0, 96] range for 96x96 images
-        x = torch.clamp(x, min=0.0, max=96.0)
+        # Clamp coordinates to [0, 1] range (normalized coordinates)
+        x = torch.clamp(x, min=0.0, max=1.0)
         
         return x
 

--- a/test_coordinate_clamp.py
+++ b/test_coordinate_clamp.py
@@ -12,7 +12,7 @@ import numpy as np
 from models.cnn_model import create_model
 
 def test_coordinate_clamp():
-    """Test that all models properly clamp coordinates to [0, 96] range"""
+    """Test that all models properly clamp coordinates to [0, 1] range (normalized)"""
     
     print("🧪 Testing coordinate clamping for all model types...")
     
@@ -50,11 +50,11 @@ def test_coordinate_clamp():
             if min_val < 0.0:
                 print(f"❌ {model_type}: Minimum coordinate {min_val:.4f} is below 0.0")
                 all_tests_passed = False
-            elif max_val > 96.0:
-                print(f"❌ {model_type}: Maximum coordinate {max_val:.4f} is above 96.0")
+            elif max_val > 1.0:
+                print(f"❌ {model_type}: Maximum coordinate {max_val:.4f} is above 1.0")
                 all_tests_passed = False
             else:
-                print(f"✅ {model_type}: Coordinates properly clamped to [0.0, 96.0]")
+                print(f"✅ {model_type}: Coordinates properly clamped to [0.0, 1.0]")
                 print(f"   Range: [{min_val:.4f}, {max_val:.4f}]")
             
         except Exception as e:
@@ -66,10 +66,10 @@ def test_coordinate_clamp():
     print("="*60)
     
     if all_tests_passed:
-        print("🎉 All models successfully clamp coordinates to [0, 96] range!")
+        print("🎉 All models successfully clamp coordinates to [0, 1] range!")
         print("\n✅ Implementation verified:")
-        print("   • All model forward functions include torch.clamp(x, min=0.0, max=96.0)")
-        print("   • Output coordinates are guaranteed to be within [0, 96] for 96x96 images")
+        print("   • All model forward functions include torch.clamp(x, min=0.0, max=1.0)")
+        print("   • Output coordinates are normalized to [0, 1] range")
         print("   • Both x and y coordinates are properly constrained")
     else:
         print("❌ Some coordinate clamping tests failed.")
@@ -102,7 +102,7 @@ def test_extreme_case():
     
     print(f"   Output range with extreme weights: [{min_val:.4f}, {max_val:.4f}]")
     
-    if min_val >= 0.0 and max_val <= 96.0:
+    if min_val >= 0.0 and max_val <= 1.0:
         print("✅ Extreme case test passed - clamping works even with large weights!")
         return True
     else:
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     if main_test_passed and extreme_test_passed:
         print("🎉 ALL TESTS PASSED!")
         print("✅ Coordinate clamping implementation is working correctly.")
-        print("✅ All models will output coordinates within [0, 96] range for 96x96 images.")
+        print("✅ All models will output normalized coordinates within [0, 1] range.")
         sys.exit(0)
     else:
         print("❌ SOME TESTS FAILED!")


### PR DESCRIPTION
Fixes #42

Fixed coordinate normalization mismatch that caused models to output invalid coordinate values:

- All models now clamp coordinates to [0,1] normalized range instead of [0,96]
- Fixes BasicCNN, DeepCNN, ResNetKeypointDetector, EfficientNetKeypointDetector
- Updated test to verify correct coordinate range
- Resolves issue where models output same/invalid coordinate values

Generated with [Claude Code](https://claude.ai/code)